### PR TITLE
OT281-28

### DIFF
--- a/airflow/dags/H_uni_de_buenos_aires.py
+++ b/airflow/dags/H_uni_de_buenos_aires.py
@@ -1,0 +1,54 @@
+"""
+1 -Configurar un DAG, sin consultas, ni procesamiento. Para Hacer un ETL para 2 universidades distintas
+2- Configurar el retry para las tareas del DAG
+3- Configurar los log
+"""
+
+from datetime import timedelta, datetime
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+import logging
+
+
+# configuracion logging
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s-%(levelname)s-%(message)s', datefmt='%Y/%m/%d')
+logger = logging.getLogger(__name__)
+
+
+
+# dag configuracion
+default_args={
+    'owner': 'airflow-OT281-28',
+    'retries': 5, # Esto viene de la definicion de SQL
+    'retry_delay': timedelta(seconds=5) #fer determino 5 seg
+}
+
+
+
+#Inicializamos DAG
+with DAG(
+        'Consulta universidad UBA', 
+          default_args=default_args,
+          description='Consulta a la Universidad de Buenos Aires',
+          scudule_inverval=timedelta(hours=1), ## DAG se debe ejecutar cada 1 hora, todos los días
+          star_date=datetime(2022,8,19), ## HAY QUE DEFINIR LA FECHA
+         ) as dag:
+
+        #0 - init Log
+        log_init = PythonOperator(
+            
+        )
+
+        #1 - Data from postgres database
+        uba_select_query=PythonOperator(
+        )
+        
+        #2 - Transforms Data
+        uba_pandas_transform=PythonOperator(
+        )
+ 
+        #3 - Load Data
+        uba_load_data=PythonOperator(
+        )
+
+        uba_select_query >> uba_pandas_transform >> uba_load_data

--- a/airflow/dags/H_uni_del_cine.py
+++ b/airflow/dags/H_uni_del_cine.py
@@ -1,0 +1,50 @@
+"""
+1 -Configurar un DAG, sin consultas, ni procesamiento. Para Hacer un ETL para 2 universidades distintas
+2- Configurar el retry para las tareas del DAG
+3- Configurar los log
+"""
+
+from datetime import timedelta, datetime
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+import logging
+
+
+# configuracion logging
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s-%(levelname)s-%(message)s', datefmt='%Y/%m/%d')
+logger = logging.getLogger(__name__)
+
+
+
+# dag configuracion
+default_args={
+    'owner': 'airflow-OT281-28',
+    'retries': 5, # Esto viene de la definicion de SQL
+    'retry_delay': timedelta(seconds=5) #fer determino 5 seg
+}
+
+#Inicializamos DAG
+with DAG('Consulta universidad UDC', 
+          default_args=default_args,
+          description='Consulta a la Universidad del Cine',
+          scudule_inverval=timedelta(hours=1), ## DAG se debe ejecutar cada 1 hora, todos los días
+          star_date=datetime(2022,8,19), ## HAY QUE DEFINIR LA FECHA
+         ) as dag:
+
+        #0 - init Log
+        log_init = PythonOperator()
+
+        #1 - Data from postgres database
+        udc_select_query=PythonOperator(
+        )
+           
+        #2 - Transforms Data
+        udc_pandas_transform=PythonOperator(
+        )
+
+        #3 - Load Data
+        udc_load_data=PythonOperator(
+        )
+
+        #4 - The execution order of the DAG
+        udc_select_query >> udc_pandas_transform >> udc_load_data


### PR DESCRIPTION
OT281-28 + OT281-36 + OT281-44

COMO: Analista de datos
QUIERO: Configurar un DAG, sin consultas, ni procesamiento
PARA: Hacer un ETL para 2 universidades distintas.

Criterios de aceptación:
Configurar el DAG para procese las siguientes universidades:

Universidad Del Cine

Universidad De Buenos Aires
Documentar los operators que se deberían utilizar a futuro, teniendo en cuenta que se va a hacer dos consultas SQL (una para cada universidad), se van a procesar los datos con pandas y se van a cargar los datos en S3.  El DAG se debe ejecutar cada 1 hora, todos los días.

COMO: Analista de datos
QUIERO: Configurar los retries con la conexión al a base de datos
PARA: poder intentar nuevamente si la base de datos me produce un error

Criterios de aceptación:
Configurar el retry para las tareas del DAG de las siguientes universidades:

Universidad Del Cine

Universidad De Buenos Aires

Descripción

COMO: Analista de datos
QUIERO: Configurar los log
PARA: Mostrarlos en consola

Criterios de aceptación:

Configurar logs para Universidad Del Cine

Configurar logs para Universidad De Buenos Aires

Utilizar la librería de Loggin de python: https://docs.python.org/3/howto/logging.html

Realizar un log al empezar cada DAG con el nombre del logger

Formato del log: %Y-%m-%d - nombre_logger - mensaje
Aclaración:
Deben dejar la configuración lista para que se pueda incluir dentro de las funciones futuras. No es necesario empezar a escribir logs.