### PR TITLE
OT281-41 logs E

### DIFF
--- a/airflow/dags/E_uni_abierta_interamericana.py
+++ b/airflow/dags/E_uni_abierta_interamericana.py
@@ -7,11 +7,18 @@
 """
 
 from datetime import timedelta, datetime
+import logging
 
 from airflow import DAG
 
 from airflow.operators.python import PythonOperator
 #from airflow.hooks.S3_hook import S3Hook
+
+
+#Logs config
+logging.basicConfig(level=logging.INFO, datefmt= '%Y-%m-%d',
+                    format='%(asctime)s - %(name)s - %(message)s',
+                    level=logging.DEBUG) 
 
 default_args = {
     'email':[''],

--- a/airflow/dags/E_uni_nacional_de_la_pampa.py
+++ b/airflow/dags/E_uni_nacional_de_la_pampa.py
@@ -7,11 +7,17 @@
 """
 
 from datetime import timedelta, datetime
+import logging
 
 from airflow import DAG
 
 from airflow.operators.python import PythonOperator
 #from airflow.hooks.S3_hook import S3Hook
+
+#Logs config
+logging.basicConfig(level=logging.INFO, datefmt= '%Y-%m-%d',
+                    format='%(asctime)s - %(name)s - %(message)s',
+                    level=logging.DEBUG) 
 
 default_args = {
     'email':[''],


### PR DESCRIPTION
OT281-41 - Grupo E
COMO: Analista de datos
QUIERO: Configurar los log
PARA: Mostrarlos en consola

Criterios de aceptación: 

- Configurar logs para Universidad Nacional De La Pampa
- Configurar logs para Universidad Abierta Interamericana
- Realizar un log al empezar cada DAG con el nombre del logger
- Formato del log: %Y-%m-%d - nombre_logger - mensaje