### PR TITLE
OT281-96

### DIFF
--- a/bigdata/logs/D_logger.cfg
+++ b/bigdata/logs/D_logger.cfg
@@ -1,0 +1,32 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler, fileHandler
+
+[formatters]
+keys=consoleFormatter, fileFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+formatter=consoleFormatter
+args=(sys.stdout,)
+
+[formatter_consoleFormatter]
+class=logging.Formatter
+format=%(asctime)s;%(levelname)s;%(name)s;%(message)s
+datefmt=%Y-%m-%d
+
+[handler_fileHandler]
+class=FileHandler
+formatter=fileFormatter
+args=('bigdata/logs/D_log.log', 'w')
+
+[formatter_fileFormatter]
+class=logging.Formatter
+format=%(asctime)s;%(levelname)s;%(name)s;%(message)s
+datefmt=%Y-%m-%d


### PR DESCRIPTION
# Summary
Added configuration file (.cfg) for group D logger in "logs" folder following team conventions.

# Notes
- The logger writes in console and in a .log file inside "logs" folder too.
- The logger is called "root" and has 2 handlers and 2 formatters (for both console and .log file).
- The message is formatted as follows: %Y/%m/%d;levelname;name;message (for both console and .log file).
- The logger level is DEBUG.

# Jira Story Link
https://alkemy-labs.atlassian.net/browse/OT281-96?atlOrigin=eyJpIjoiYmQ4MWUwMmI0ZmIwNGQwOWFhNGFkM2UwYmZiOGU0ZmUiLCJwIjoiaiJ9