### PR TITLE
OT281-100

### DIFF
--- a/bigdata/logs/H_logger.cfg
+++ b/bigdata/logs/H_logger.cfg
@@ -1,0 +1,34 @@
+
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler,fileHandler
+
+[formatters]
+keys=consoleFormatter,fileFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=consoleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=FileHandler
+formatter=fileFormatter
+kwargs={'bigdata/logs/H_log.log'}
+
+[formatter_consoleFormatter]
+class = logging.Formatter
+format=%(asctime)s_%(levelname)s%(name)s_%(message)s
+datefmt=%A.%B.%Y
+
+[formatter_fileFormatter]
+class = logging.Formatter
+format=%(asctime)s_%(levelname)s%(name)s_%(message)s
+datefmt=%A.%B.%Y


### PR DESCRIPTION
COMO: Analista de datos
QUIERO: Configurar los log
PARA: Mostrarlos en consola

Criterios de aceptación:

Utilizar Libreria Loging.

Loguear en 2 hilos por consola y por fichero rotativo cada 7 dias.

Consola: %A.%B.%Y_levelnamename_message

Fichero:  %A.%B.%Y_levelnamename_message

La configuración debe estar en un archivo .cfg